### PR TITLE
(1) Refactor, in ObjectCompose, the boxSize should be fixed for every…

### DIFF
--- a/app/src/main/java/com/example/overrun/enitities/gameobject/ObjectCompose.kt
+++ b/app/src/main/java/com/example/overrun/enitities/gameobject/ObjectCompose.kt
@@ -29,7 +29,8 @@ fun ObjectCompose(
     gameObject: GameObject,
     gameMetricsAndCtrl: GameMetricsAndControl,
     colliderManager: ColliderManager,
-    objectSizeAndViewManager : GameObjectSizeAndViewManager
+    objectSizeAndViewManager : GameObjectSizeAndViewManager,
+    boxSize: Dp
 ) {
     if (gameObject.getIsDestroy()) {
         return  // Just bail out, skip drawing
@@ -115,6 +116,9 @@ fun ObjectCompose(
     }
 
     // For not within the Screen, skip rendering
+//    val isVisible = rememberUpdatedState(objectSizeAndViewManager.IsObjectInScreen(gameObject.getCollider()))
+//    if (!isVisible.value) return
+
     if (!objectSizeAndViewManager.IsObjectInScreen(gameObject.getCollider())) {
         return
     }
@@ -127,8 +131,8 @@ fun ObjectCompose(
     val xScreenPos by rememberUpdatedState(objectSizeAndViewManager.screenWorldX)
     val yScreenPos by rememberUpdatedState(objectSizeAndViewManager.screenWorldY)
 
-    val density = LocalDensity.current
-    val boxSize = with(density) { objectSizeAndViewManager.GET_OBJECT_SIZE().toFloat().toDp() }
+//    val density = LocalDensity.current
+//    val boxSize = with(density) { objectSizeAndViewManager.GET_OBJECT_SIZE().toFloat().toDp() }
 
     var lastColor by remember { mutableStateOf(Color.DarkGray) }
     var filterOpacity by remember { mutableStateOf(0f) }
@@ -171,11 +175,12 @@ fun ObjectCompose(
     // Debug log (if needed)
     // Log.i("Object", "Type ${gameObject.getObjType()}  id : ${gameObject.getID()} x : ${gameObject.getXPos()}  y : ${gameObject.getYPos()}")
 
-    Box(Modifier.fillMaxSize()) {
+    //Box(Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .size(boxSize)
-                .align(Alignment.TopStart)
+                //.align(Alignment.TopStart)
+
                 // don't use graphicLayer since its transformation would auto scaling and translate
                 // may cause edge residue issue for the rendering
                 // .graphicsLayer {
@@ -328,5 +333,5 @@ fun ObjectCompose(
                 }
             }
         }
-    }
+    //}
 }

--- a/app/src/main/java/com/example/overrun/ui/screens/LevelBase_Screen.kt
+++ b/app/src/main/java/com/example/overrun/ui/screens/LevelBase_Screen.kt
@@ -41,6 +41,12 @@ fun LevelBase_Screen(navController: NavController,
     val density = LocalDensity.current
     val context = LocalContext.current
 
+    val boxSize = remember(density){
+        with(density) {
+            gameViewModel.objectSizeAndViewManager.GET_OBJECT_SIZE().toFloat().toDp()
+        }
+    }
+
     val isGameStageInitialized = remember { mutableStateOf(false) }
 
     // declare for re-render trigger
@@ -100,7 +106,8 @@ fun LevelBase_Screen(navController: NavController,
                     ObjectCompose(gameObj,
                         gameViewModel.gameMetricsAndCtrl,
                         gameViewModel.colliderManager,
-                        gameViewModel.objectSizeAndViewManager
+                        gameViewModel.objectSizeAndViewManager,
+                        boxSize
                     )
                 }
 


### PR DESCRIPTION
… render, thus

move to upper layer for calculating once and passing into each object (2) Refactor, in ObjectCompose, remove the redundant box() with fill max size rendering (3) The changes is positive to have more smoother in rendering the background when hero character move